### PR TITLE
Add fix for period check in javadoc first comment line

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -146,6 +146,10 @@ page at http://checkstyle.sourceforge.net/config.html -->
             <property name="severity" value="error" />
         </module>
 
+        <module name="SummaryJavadocCheck">
+            <property name="period" value="."/>
+        </module>
+
         <!--
 
         NAMING CHECKS

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -144,6 +144,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
         <module name="JavadocStyle">
             <property name="severity" value="error" />
+            <property name="checkFirstSentence" value="true"/>
         </module>
 
         <module name="SummaryJavadocCheck">


### PR DESCRIPTION
## Purpose
> Checkstyle check behave differently for windows and linux, such that in windows it checks whether javadoc first line ends with a period, but in linux it's not

## Goals
> This will introduce a fix which will validate the line end in linux.

## Approach
> Added below tag, which solves the problem
 ```xml
<module name="SummaryJavadocCheck">
   <property name="period" value="."/>
</module>
```
## User stories
> Since this will show javadoc errors in linux as well, that will enforce fixing them in linux, hence ultimately windows users won't have to worry about javadoc failures

## Release note
> Adding javadoc first line end with period validation

## Documentation
> N/A

## Certification
> N/A this is a checkstyle change, hence no need of certification.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 
## Learning
> http://checkstyle.sourceforge.net/config_javadoc.html#SummaryJavadoc