### PR TITLE
Fix JavaDoc first sentence should end with period

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -146,6 +146,10 @@ page at http://checkstyle.sourceforge.net/config.html -->
             <property name="severity" value="error" />
         </module>
 
+        <module name="SummaryJavadocCheck">
+            <property name="period" value="."/>
+        </module>
+
         <!--
 
         NAMING CHECKS


### PR DESCRIPTION

## Purpose
Current checkstyle config only gives "first sentence should end with a period"
error on windows. This is to fix it to give the error on all platforms.
