### PR TITLE
Skipping swagger gen files from checkstyle

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -39,5 +39,7 @@
     <!-- do not check thrift generated files -->
     <suppress checks=".*" files=".*/transaction/distributed/thrift/.*" />
 
+    <!-- do not check swagger generated files -->
+    <suppress checks=".*" files=".*/src/gen/java/.*" />
 
 </suppressions>


### PR DESCRIPTION
## Purpose
> Build is failing due to checkstyle validation failure for the maven msf4j-swagger-codegen plugin generated resources.

## Goals
> Skip checkstyle validations for the generated source files(eg. swagger maven plugin generated code).

## Approach
> Common file pattern introduced for the generated files.