### PR TITLE
Add UTF-8 as charset.

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -24,7 +24,9 @@ what the following rules do, please see the checkstyle configuration
 page at http://checkstyle.sourceforge.net/config.html -->
 
 <module name="Checker">
-
+    
+    <property name="charset" value="UTF-8"/>
+ 
     <module name="FileTabCharacter">
         <property name="severity" value="error" />
         <!-- Checks that there are no tab characters in the file.


### PR DESCRIPTION
## Purpose
Configure a Checker rule, so that it handles files with the UTF-8 charset. 

http://checkstyle.sourceforge.net/config.html#Checker_Properties

## Goals
This allows using the same check style checker rules, with The Gradle on windows. 

## Approach
Right now this is handled explicitly at [carbon-parent pom](https://github.com/wso2/carbon-parent/blob/master/pom.xml#L198).  This works for maven based build, but doesn't work for Gradle based builds.  Additionally [maven-checkstyle-plugin's encoding](https://maven.apache.org/plugins/maven-checkstyle-plugin/check-mojo.html#encoding)  always overrides the property charset from Checkstyle's TreeWalker module.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
Windows
