### PR TITLE
Update checkstyle.xml

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -63,6 +63,21 @@ page at http://checkstyle.sourceforge.net/config.html -->
         <property name="message" value='All TODOs should be named.  e.g. "TODO: (ENG-123) - Refactor when v2 is released."' />
     </module>
 
+    <module name="LineLength">
+        <!-- Checks if a line is too long. -->
+        <property name="max" value="120" default="120" />
+        <property name="severity" value="error" />
+
+        <!--
+          The default ignore pattern exempts the following elements:
+            - import statements
+            - long URLs inside comments
+        -->
+
+        <property name="ignorePattern" value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.ignorePattern}"
+                  default="^(package .*;\s*)|(import .*;\s*)|( *\* *https?://.*)$" />
+    </module>
+
     <!--<module name="JavadocPackage">-->
         <!--&lt;!&ndash; Checks that each Java package has a Javadoc file used for commenting.-->
           <!--Only allows a package-info.java, not package.html. &ndash;&gt;-->
@@ -71,9 +86,6 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
     <!-- All Java AST specific tests live under TreeWalker module. -->
     <module name="TreeWalker">
-
-        <!-- required for SupressionCommentFilter and SuppressWithNearbyCommentFilter -->
-        <module name="FileContentsHolder" />
 
         <!--
 
@@ -131,12 +143,12 @@ page at http://checkstyle.sourceforge.net/config.html -->
         <module name="JavadocMethod">
             <property name="scope" value="protected" />
             <property name="severity" value="error" />
-            <property name="allowMissingJavadoc" value="true" />
             <property name="allowMissingParamTags" value="true" />
             <property name="allowMissingReturnTag" value="true" />
-            <property name="allowMissingThrowsTags" value="true" />
-            <property name="allowThrowsTagsForSubclasses" value="true" />
-            <property name="allowUndeclaredRTE" value="true" />
+        </module>
+
+        <module name="MissingJavadocMethodCheck">
+            <property name="allowMissingPropertyJavadoc" value="true"/>
         </module>
 
         <module name="JavadocType">
@@ -241,21 +253,6 @@ page at http://checkstyle.sourceforge.net/config.html -->
         LENGTH and CODING CHECKS
 
         -->
-
-        <module name="LineLength">
-            <!-- Checks if a line is too long. -->
-            <property name="max" value="120" default="120" />
-            <property name="severity" value="error" />
-
-            <!--
-              The default ignore pattern exempts the following elements:
-                - import statements
-                - long URLs inside comments
-            -->
-
-            <property name="ignorePattern" value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.ignorePattern}"
-                default="^(package .*;\s*)|(import .*;\s*)|( *\* *https?://.*)$" />
-        </module>
 
         <module name="LeftCurly">
             <!-- Checks for placement of the left curly brace ('{'). -->
@@ -399,17 +396,18 @@ page at http://checkstyle.sourceforge.net/config.html -->
             <property name="format" value="e\.printStackTrace\(\)" />
             <property name="illegalPattern" value="true" />
         </module>
+
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE OFF: (.+)" />
+            <property name="onCommentFormat" value="CHECKSTYLE ON" />
+            <property name="checkFormat" value="Javadoc.*" />
+            <property name="messageFormat" value="$1" />
+        </module>
+
     </module>
 
     <!--module name="SuppressionFilter">
         <property name="file" value="suppressions.xml"/>
     </module-->
-
-    <module name="SuppressionCommentFilter">
-        <property name="offCommentFormat" value="CHECKSTYLE OFF: (.+)" />
-        <property name="onCommentFormat" value="CHECKSTYLE ON" />
-        <property name="checkFormat" value="Javadoc.*" />
-        <property name="messageFormat" value="$1" />
-    </module>
 
 </module>


### PR DESCRIPTION
This will add below changes to checkstyle.xml,

1. Removing three properties(**allowMissingThrowsTags, allowThrowsTagsForSubclasses, allowUndeclaredRTE**) which were listed under **JavadocMethod** Module since they were removed from new versions of checkstyle. And this change is explained with this [1](https://github.com/checkstyle/checkstyle/issues/7329).
2. Adding **allowMissingPropertyJavadoc** property under a separate module named **MissingJavadocMethodCheck**. This property was previously listed under **JavadocMethod** module as **allowMissingJavadoc**. And this change is explained with this [2](https://github.com/checkstyle/checkstyle/issues/6703).
3. Module **LineLength** which was listed under **TreeWalker** module is now taken out from **TreeWalker** module. And this change is explained with this [3](https://github.com/checkstyle/checkstyle/issues/2116).
4. Removing **FileContentsHolder** module. And this change is explained with this [4](https://github.com/checkstyle/checkstyle/issues/3573).
5. Module **SuppressionCommentFilter** is taken inside to **TreeWalker** module. And this change is explained with this [5](https://github.com/checkstyle/checkstyle/issues/4714).